### PR TITLE
oneshot command finishes with 0 status when it occurs error.

### DIFF
--- a/cmd/oneshot.go
+++ b/cmd/oneshot.go
@@ -34,14 +34,16 @@ func NewOneshotCommand(out, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "oneshot [options] COMMAND",
 		Short: "",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			f.command = args
 
 			l := log.NewLogger(f.cluster, f.taskDefName, "", out)
 			err := f.execute(cmd, args, l)
 			if err != nil {
 				l.Log(fmt.Sprintf("error: %s\n", err.Error()))
+				return err
 			}
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&f.cluster, "cluster", "", "ECS cluster name")

--- a/main.go
+++ b/main.go
@@ -32,6 +32,6 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
issue: https://github.com/SKAhack/shipctl/issues/10

Oneshot command finished with 1 status when error.

I also change error status from -1 to 1 in reference to http://tldp.org/LDP/abs/html/exitcodes.html.